### PR TITLE
AppChain - Multicall3 contract

### DIFF
--- a/src/definitions/appchain.ts
+++ b/src/definitions/appchain.ts
@@ -25,6 +25,10 @@ export const appchain = /*#__PURE__*/ defineChain({
   },
   contracts: {
     ...chainConfig.contracts,
+    multicall3: {
+      address: '0x2055A30B00555e7cAd48b1756eac4f917781489b',
+      blockCreated: 423306,
+    },
     hyperlaneMailbox: {
       address: '0x3a464f746D23Ab22155710f44dB16dcA53e0775E',
     },


### PR DESCRIPTION
This pull request adds a new contract definition to the `appchain` configuration in `src/definitions/appchain.ts`.

Contract addition:

* [`src/definitions/appchain.ts`](diffhunk://#diff-933e9080dd879b27d2cf14613f2709591915745276dd2b31afc7eb0fd4273c0eR28-R31): Added the `multicall3` contract with its address (`0x2055A30B00555e7cAd48b1756eac4f917781489b`) and the block number where it was created (`423306`).