### PR TITLE
Metalayer router to more chains

### DIFF
--- a/src/assets/chain.json
+++ b/src/assets/chain.json
@@ -25,7 +25,8 @@
   },
   "8453": {
     "url": "https://base-mainnet.g.alchemy.com/v2/${ALCHEMY_API_KEY}",
-    "mailbox": "0xeA87ae93Fa0019a82A727bfd3eBd1cFCa8f64f1D"
+    "mailbox": "0xeA87ae93Fa0019a82A727bfd3eBd1cFCa8f64f1D",
+    "route": "0x09ce71c24ee2098e351c0cf2dc6431b414d247f3"
   },
   "33111": {
     "url": "https://curtis.rpc.caldera.xyz/${CURTIS_API_KEY}",
@@ -33,7 +34,8 @@
   },
   "42161": {
     "url": "https://arb-mainnet.g.alchemy.com/v2/${ALCHEMY_API_KEY}",
-    "mailbox": "0x979Ca5202784112f4738403dBec5D0F3B9daabB9"
+    "mailbox": "0x979Ca5202784112f4738403dBec5D0F3B9daabB9",
+    "route": "0x09ce71c24ee2098e351c0cf2dc6431b414d247f3"
   },
   "42220": {
     "url": "https://celo-mainnet.g.alchemy.com/v2/${ALCHEMY_API_KEY}",
@@ -79,7 +81,8 @@
   },
   "478": {
     "url": "https://rpc.form.network/http",
-    "mailbox": "0x3a464f746D23Ab22155710f44dB16dcA53e0775E"
+    "mailbox": "0x3a464f746D23Ab22155710f44dB16dcA53e0775E",
+    "router": "0x09cE71C24EE2098e351C0cF2dC6431B414d247f3"
   },
   "2525": {
     "url": "https://inevm.calderachain.xyz/http",
@@ -87,11 +90,13 @@
   },
   "169": {
     "url": "https://manta-pacific.calderachain.xyz/http",
-    "mailbox": "0x3a464f746D23Ab22155710f44dB16dcA53e0775E"
+    "mailbox": "0x3a464f746D23Ab22155710f44dB16dcA53e0775E",
+    "router": "0x09cE71C24EE2098e351C0cF2dC6431B414d247f3"
   },
   "360": {
     "url": "https://molten.calderachain.xyz/http",
-    "mailbox": "0x4E55aDA3ef1942049EA43E904EB01F4A0a9c39bd"
+    "mailbox": "0x4E55aDA3ef1942049EA43E904EB01F4A0a9c39bd",
+    "router": "0x09cE71C24EE2098e351C0cF2dC6431B414d247f3"
   },
   "1380012617": {
     "url": "https://rari.calderachain.xyz/http",
@@ -100,7 +105,8 @@
   },
   "1996": {
     "url": "https://mainnet.sanko.xyz",
-    "mailbox": "0x2f2aFaE1139Ce54feFC03593FeE8AB2aDF4a85A7"
+    "mailbox": "0x2f2aFaE1139Ce54feFC03593FeE8AB2aDF4a85A7",
+    "router": "0x09cE71C24EE2098e351C0cF2dC6431B414d247f3"
   },
   "1992": {
     "url": "https://sanko-arb-sepolia.rpc.caldera.xyz/http",


### PR DESCRIPTION
This pull request updates the `src/assets/chain.json` file to include new `route` or `router` fields for several blockchain configurations. These additions enhance the configuration by specifying routing addresses for better network communication.

### Updates to Blockchain Configuration:

* **Mainnet Chains**:
  - Added `route` field for chain IDs `8453` and `42161`.

* **Form Network and Caldera Chains**:
  - Added `router` field for chain IDs `478`, `169`, and `360`.

* **Sanko Chain**:
  - Added `router` field for chain ID `1996`.