### PR TITLE
Add Metalayer router Arb and Base

### DIFF
--- a/src/assets/chain.json
+++ b/src/assets/chain.json
@@ -26,7 +26,7 @@
   "8453": {
     "url": "https://base-mainnet.g.alchemy.com/v2/${ALCHEMY_API_KEY}",
     "mailbox": "0xeA87ae93Fa0019a82A727bfd3eBd1cFCa8f64f1D",
-    "route": "0x09ce71c24ee2098e351c0cf2dc6431b414d247f3"
+    "router": "0x09ce71c24ee2098e351c0cf2dc6431b414d247f3"
   },
   "33111": {
     "url": "https://curtis.rpc.caldera.xyz/${CURTIS_API_KEY}",
@@ -35,7 +35,7 @@
   "42161": {
     "url": "https://arb-mainnet.g.alchemy.com/v2/${ALCHEMY_API_KEY}",
     "mailbox": "0x979Ca5202784112f4738403dBec5D0F3B9daabB9",
-    "route": "0x09ce71c24ee2098e351c0cf2dc6431b414d247f3"
+    "router": "0x09ce71c24ee2098e351c0cf2dc6431b414d247f3"
   },
   "42220": {
     "url": "https://celo-mainnet.g.alchemy.com/v2/${ALCHEMY_API_KEY}",


### PR DESCRIPTION
This pull request includes a small but important update to the `src/assets/chain.json` file. The changes correct the property name from `route` to `router` for several blockchain configurations.