### PR TITLE
Add a new custom rpc url group to use multiple urls from mixed providers

### DIFF
--- a/src/definitions/optimism.ts
+++ b/src/definitions/optimism.ts
@@ -5,9 +5,15 @@ export const optimism: EcoChain = {
   ...vop,
   rpcUrls: {
     ...vop.rpcUrls,
-    alchemy: {
-      http: ['https://opt-mainnet.g.alchemy.com/v2/${ALCHEMY_API_KEY}'],
-      webSocket: ['wss://opt-mainnet.g.alchemy.com/v2/${ALCHEMY_API_KEY}'],
+    custom: {
+      http: [
+        'https://opt-mainnet.g.alchemy.com/v2/${ALCHEMY_API_KEY}',
+        'https://optimism-mainnet.infura.io/v3/${INFURA_API_KEY}',
+      ],
+      webSocket: [
+        'wss://opt-mainnet.g.alchemy.com/v2/${ALCHEMY_API_KEY}',
+        'wss://optimism-mainnet.infura.io/ws/v3/${INFURA_API_KEY}',
+      ],
     },
   },
   contracts: {
@@ -29,9 +35,15 @@ export const optimismSepolia: EcoChain = {
   ...vops,
   rpcUrls: {
     ...vops.rpcUrls,
-    alchemy: {
-      http: ['https://opt-sepolia.g.alchemy.com/v2/${ALCHEMY_API_KEY}'],
-      webSocket: ['wss://opt-sepolia.g.alchemy.com/v2/${ALCHEMY_API_KEY}'],
+    custom: {
+      http: [
+        'https://opt-sepolia.g.alchemy.com/v2/${ALCHEMY_API_KEY}',
+        'https://optimism-sepolia.infura.io/v3/${INFURA_API_KEY}',
+      ],
+      webSocket: [
+        'wss://opt-sepolia.g.alchemy.com/v2/${ALCHEMY_API_KEY}',
+        'wss://optimism-sepolia.infura.io/v3/${INFURA_API_KEY}',
+      ],
     },
   },
   contracts: {


### PR DESCRIPTION
Adds a new custom RPC group to be used with multiple urls from mixed providers. 

Refactors the `getChain` method to improve how RPC URLs are processed. The new implementation iterates through all RPC groups and replaces API key placeholders in-place, which resolves a bug where a `custom` property was being repeatedly overwritten.

For backward compatibility, a fallback has been introduced. If a chain definition does not include an explicit `custom` RPC group, the function now automatically assigns the last available non-default provider to `custom`.

All associated tests have been updated to align with the new, more predictable behavior and to verify the fallback mechanism.