### PR TITLE
Added RPC and Transport utilities to EcoChains class

### DIFF
--- a/src/eco.chains.ts
+++ b/src/eco.chains.ts
@@ -145,6 +145,13 @@ export class EcoChains {
     return chain.stables || {}
   }
 
+  /**
+   * Retrieves RPC URLs for a specific chain, optionally filtering by WebSocket support
+   *
+   * @param chainID - The ID of the chain to retrieve RPC URLs for
+   * @param opts - Options for filtering RPC URLs
+   * @returns {string[]} - An array of RPC URLs for the specified chain
+   */
   getRpcUrlsForChain(chainID: number, opts: RpcOptions): string[] {
     const { isWebSocketEnabled = true } = opts
     const rpcChain = this.getChain(chainID)
@@ -160,6 +167,14 @@ export class EcoChains {
     return rpcUrls
   }
 
+  /**
+   * Retrieves transports for a specific chain, creating WebSocket or HTTP transports
+   * based on the RPC URLs available for that chain.
+   *
+   * @param chainID - The ID of the chain to retrieve transports for
+   * @param opts - Options for filtering RPC URLs
+   * @returns {Transport[]} - An array of Transport objects for the specified chain
+   */
   getTransportsForChain(chainID: number, opts: RpcOptions): Transport[] {
     const rpcUrls = this.getRpcUrlsForChain(chainID, opts)
     return rpcUrls.reduce<Transport[]>((acc, url) => {
@@ -172,6 +187,14 @@ export class EcoChains {
     }, [])
   }
 
+  /**
+   * Retrieves transports for all chains, creating a fallback transport for each chain
+   * based on the available RPC URLs.
+   *
+   * @param chains - An array of EcoChain objects to retrieve transports for
+   * @param opts - Options for filtering RPC URLs
+   * @returns {Record<number, Transport>} - A record mapping chain IDs to Transport objects
+   */
   getTransports(chains: EcoChain[], opts: RpcOptions): Record<number, Transport> {
     return chains.reduce<Record<number, Transport>>((acc, chain) => {
       const transports = this.getTransportsForChain(chain.id, opts)

--- a/src/eco.chains.ts
+++ b/src/eco.chains.ts
@@ -1,4 +1,4 @@
-import { extractChain, fallback, Hex, http, Transport, TransportConfig, webSocket } from 'viem'
+import { extractChain, fallback, Hex, http, Transport, webSocket } from 'viem'
 import { EcoRoutesChains, EcoChain } from './index'
 
 /**
@@ -195,7 +195,10 @@ export class EcoChains {
    * @param opts - Options for filtering RPC URLs
    * @returns {Record<number, Transport>} - A record mapping chain IDs to Transport objects
    */
-  getTransports(chains: EcoChain[], opts: RpcOptions = {}): Record<number, Transport> {
+  getTransports(
+    chains: EcoChain[],
+    opts: RpcOptions = {},
+  ): Record<number, Transport> {
     return chains.reduce<Record<number, Transport>>((acc, chain) => {
       const transports = this.getTransportsForChain(chain.id, opts)
       if (transports.length > 0) {

--- a/src/eco.chains.ts
+++ b/src/eco.chains.ts
@@ -152,7 +152,7 @@ export class EcoChains {
    * @param opts - Options for filtering RPC URLs
    * @returns {string[]} - An array of RPC URLs for the specified chain
    */
-  getRpcUrlsForChain(chainID: number, opts: RpcOptions): string[] {
+  getRpcUrlsForChain(chainID: number, opts: RpcOptions = {}): string[] {
     const { isWebSocketEnabled = true } = opts
     const rpcChain = this.getChain(chainID)
     const custom = rpcChain.rpcUrls.custom
@@ -175,7 +175,7 @@ export class EcoChains {
    * @param opts - Options for filtering RPC URLs
    * @returns {Transport[]} - An array of Transport objects for the specified chain
    */
-  getTransportsForChain(chainID: number, opts: RpcOptions): Transport[] {
+  getTransportsForChain(chainID: number, opts: RpcOptions = {}): Transport[] {
     const rpcUrls = this.getRpcUrlsForChain(chainID, opts)
     return rpcUrls.reduce<Transport[]>((acc, url) => {
       if (url.startsWith('ws://') || url.startsWith('wss://')) {
@@ -195,7 +195,7 @@ export class EcoChains {
    * @param opts - Options for filtering RPC URLs
    * @returns {Record<number, Transport>} - A record mapping chain IDs to Transport objects
    */
-  getTransports(chains: EcoChain[], opts: RpcOptions): Record<number, Transport> {
+  getTransports(chains: EcoChain[], opts: RpcOptions = {}): Record<number, Transport> {
     return chains.reduce<Record<number, Transport>>((acc, chain) => {
       const transports = this.getTransportsForChain(chain.id, opts)
       if (transports.length > 0) {

--- a/src/eco.chains.ts
+++ b/src/eco.chains.ts
@@ -19,10 +19,7 @@ export const ConfigRegex = {
  * Keys correspond to provider names defined in ConfigRegex
  * Values are the API keys to be inserted into the RPC URLs
  */
-export type EcoChainConfigs = {
-  // eslint-disable-next-line no-unused-vars
-  [key in keyof typeof ConfigRegex]?: string
-}
+export type EcoChainConfigs = Partial<Record<keyof typeof ConfigRegex, string>>
 
 /**
  * Options for RPC URL or Transport retrieval

--- a/src/tests/eco.chains.spec.ts
+++ b/src/tests/eco.chains.spec.ts
@@ -293,12 +293,16 @@ describe('Eco Chains', () => {
     const rpcs = getRpcUrls({ default: defaults, alchemy })
     mockViemExtract.mockReturnValue(cloneDeep(rpcs))
     const obj = new EcoChains(config)
-    
+
     const urls = obj.getRpcUrlsForChain(1)
-    
-    expect(urls).toContain(`wss://opt-mainnet.g.alchemy.com/v2/${config.alchemyKey}`)
+
+    expect(urls).toContain(
+      `wss://opt-mainnet.g.alchemy.com/v2/${config.alchemyKey}`,
+    )
     expect(urls).toContain('wss://etherscan.io/api')
-    expect(urls).toContain(`https://base-mainnet.g.alchemy.com/v2/${config.alchemyKey}`)
+    expect(urls).toContain(
+      `https://base-mainnet.g.alchemy.com/v2/${config.alchemyKey}`,
+    )
     expect(urls).toContain('https://etherscan.io/api')
   })
 
@@ -306,12 +310,16 @@ describe('Eco Chains', () => {
     const rpcs = getRpcUrls({ default: defaults, alchemy })
     mockViemExtract.mockReturnValue(cloneDeep(rpcs))
     const obj = new EcoChains(config)
-    
+
     const urls = obj.getRpcUrlsForChain(1, { isWebSocketEnabled: false })
-    
-    expect(urls).not.toContain(`wss://opt-mainnet.g.alchemy.com/v2/${config.alchemyKey}`)
+
+    expect(urls).not.toContain(
+      `wss://opt-mainnet.g.alchemy.com/v2/${config.alchemyKey}`,
+    )
     expect(urls).not.toContain('wss://etherscan.io/api')
-    expect(urls).toContain(`https://base-mainnet.g.alchemy.com/v2/${config.alchemyKey}`)
+    expect(urls).toContain(
+      `https://base-mainnet.g.alchemy.com/v2/${config.alchemyKey}`,
+    )
     expect(urls).toContain('https://etherscan.io/api')
   })
 
@@ -319,61 +327,65 @@ describe('Eco Chains', () => {
     const rpcs = getRpcUrls({ default: defaults, alchemy })
     mockViemExtract.mockReturnValue(cloneDeep(rpcs))
     const obj = new EcoChains(config)
-    
+
     const urls = obj.getRpcUrlsForChain(1)
-    
+
     // Custom URLs should come first
-    const alchemyHttpIndex = urls.indexOf(`https://base-mainnet.g.alchemy.com/v2/${config.alchemyKey}`)
+    const alchemyHttpIndex = urls.indexOf(
+      `https://base-mainnet.g.alchemy.com/v2/${config.alchemyKey}`,
+    )
     const defaultHttpIndex = urls.indexOf('https://etherscan.io/api')
     expect(alchemyHttpIndex).toBeLessThan(defaultHttpIndex)
   })
 
   it('should create http transports for https URLs', () => {
-    const rpcs = getRpcUrls({ 
+    const rpcs = getRpcUrls({
       default: {
-        http: ['https://etherscan.io/api']
-      }
+        http: ['https://etherscan.io/api'],
+      },
     })
     mockViemExtract.mockReturnValue(cloneDeep(rpcs))
     mockHttp.mockReturnValue('http-transport')
     const obj = new EcoChains(config)
-    
-    const transports = obj.getTransportsForChain(1, { isWebSocketEnabled: false })
-    
+
+    const transports = obj.getTransportsForChain(1, {
+      isWebSocketEnabled: false,
+    })
+
     expect(mockHttp).toHaveBeenCalledWith('https://etherscan.io/api')
     expect(transports).toEqual(['http-transport'])
   })
 
   it('should create websocket transports for wss URLs', () => {
-    const rpcs = getRpcUrls({ 
+    const rpcs = getRpcUrls({
       default: {
-        webSocket: ['wss://etherscan.io/api']
-      }
+        webSocket: ['wss://etherscan.io/api'],
+      },
     })
     mockViemExtract.mockReturnValue(cloneDeep(rpcs))
     mockWebSocket.mockReturnValue('websocket-transport')
     const obj = new EcoChains(config)
-    
+
     const transports = obj.getTransportsForChain(1)
-    
+
     expect(mockWebSocket).toHaveBeenCalledWith('wss://etherscan.io/api')
     expect(transports).toEqual(['websocket-transport'])
   })
 
   it('should handle mixed protocol URLs in transports', () => {
-    const rpcs = getRpcUrls({ 
+    const rpcs = getRpcUrls({
       default: {
         http: ['http://example.com', 'https://secure.example.com'],
-        webSocket: ['ws://example.com', 'wss://secure.example.com']
-      }
+        webSocket: ['ws://example.com', 'wss://secure.example.com'],
+      },
     })
     mockViemExtract.mockReturnValue(cloneDeep(rpcs))
     mockHttp.mockReturnValue('http-transport')
     mockWebSocket.mockReturnValue('websocket-transport')
     const obj = new EcoChains(config)
-    
+
     const transports = obj.getTransportsForChain(1)
-    
+
     expect(mockWebSocket).toHaveBeenCalledWith('ws://example.com')
     expect(mockWebSocket).toHaveBeenCalledWith('wss://secure.example.com')
     expect(mockHttp).toHaveBeenCalledWith('http://example.com')
@@ -382,65 +394,65 @@ describe('Eco Chains', () => {
   })
 
   it('should create fallback transports for multiple chains', () => {
-    const rpcs = getRpcUrls({ 
+    const rpcs = getRpcUrls({
       default: {
-        http: ['https://etherscan.io/api']
-      }
+        http: ['https://etherscan.io/api'],
+      },
     })
     mockViemExtract.mockReturnValue(cloneDeep(rpcs))
     mockHttp.mockReturnValue('http-transport')
     mockFallback.mockReturnValue('fallback-transport')
     const obj = new EcoChains(config)
-    
+
     const chains = [
       { id: 1, name: 'Ethereum' },
-      { id: 137, name: 'Polygon' }
+      { id: 137, name: 'Polygon' },
     ] as any[]
-    
+
     const transports = obj.getTransports(chains)
-    
+
     expect(mockFallback).toHaveBeenCalledTimes(2)
     expect(transports).toEqual({
       1: 'fallback-transport',
-      137: 'fallback-transport'
+      137: 'fallback-transport',
     })
   })
 
   it('should skip chains with no available transports in getTransports', () => {
     const obj = new EcoChains({}) // No API keys
-    
+
     // Mock a chain that would have URLs requiring API keys
-    const rpcsWithKeys = getRpcUrls({ 
+    const rpcsWithKeys = getRpcUrls({
       default: {
-        http: ['https://base-mainnet.g.alchemy.com/v2/${ALCHEMY_API_KEY}']
-      }
+        http: ['https://base-mainnet.g.alchemy.com/v2/${ALCHEMY_API_KEY}'],
+      },
     })
     mockViemExtract.mockReturnValue(cloneDeep(rpcsWithKeys))
-    
+
     const chains = [{ id: 1, name: 'Ethereum' }] as any[]
-    
+
     const transports = obj.getTransports(chains)
-    
+
     expect(mockFallback).not.toHaveBeenCalled()
     expect(transports).toEqual({})
   })
 
   it('should pass websocket options to getTransportsForChain in getTransports', () => {
-    const rpcs = getRpcUrls({ 
+    const rpcs = getRpcUrls({
       default: {
         http: ['https://etherscan.io/api'],
-        webSocket: ['wss://etherscan.io/api']
-      }
+        webSocket: ['wss://etherscan.io/api'],
+      },
     })
     mockViemExtract.mockReturnValue(cloneDeep(rpcs))
     mockHttp.mockReturnValue('http-transport')
     mockFallback.mockReturnValue('fallback-transport')
     const obj = new EcoChains(config)
-    
+
     const chains = [{ id: 1, name: 'Ethereum' }] as any[]
-    
+
     const transports = obj.getTransports(chains, { isWebSocketEnabled: false })
-    
+
     expect(mockHttp).toHaveBeenCalledWith('https://etherscan.io/api')
     expect(mockWebSocket).not.toHaveBeenCalled()
     expect(mockFallback).toHaveBeenCalledWith(['http-transport'])


### PR DESCRIPTION
## Description

This PR adds some utility methods to EcoChains for some logic that we already have in the solver but should belong here instead.

- `getRpcUrlsForChain`: get an array of rpc urls for a specific chainID
- `getTransportsForChain`: get an array of webSocket/http transports for a specific chainID
- `getTransports`: get an object which is a mapping of chainIDs to fallback transports for each chain in an array of provided EcoChains (useful for frontend applications when providing custom transports to a wallet connector config)
- `processRpcUrls`: replace api key placeholders with actual api keys and discard urls where api key is expected but not provided.

## Usage

``` ts
const ecoChains = new EcoChains({});

const mainnetRpcUrls = ecoChains.getRpcUrlsForChain(1);
const mainnetTransports = ecoChains.getTransportsForChain(1);
const allTransportsObj = ecoChains.getTransports(ecoChains.getAllChains());

const testnetHttpTransportsObj = ecoChains.getTransports(ecoChains.getTestnetChains(), { webSocketEnabled: false });