### PR TITLE
fix: Adding infura rpc urls, removing quicknode

### DIFF
--- a/src/definitions/arbitrum.ts
+++ b/src/definitions/arbitrum.ts
@@ -9,6 +9,10 @@ export const arbitrum: EcoChain = {
       http: ['https://arb-mainnet.g.alchemy.com/v2/${ALCHEMY_API_KEY}'],
       webSocket: ['wss://arb-mainnet.g.alchemy.com/v2/${ALCHEMY_API_KEY}'],
     },
+    infura: {
+      http: ['https://arbitrum-mainnet.infura.io/v3/${INFURA_API_KEY}'],
+      webSocket: ['wss://arbitrum-mainnet.infura.io/ws/v3/${INFURA_API_KEY}'],
+    },
   },
   contracts: {
     ...varbitrum.contracts,

--- a/src/definitions/base.ts
+++ b/src/definitions/base.ts
@@ -14,6 +14,10 @@ export const base: EcoChain = {
       http: ['https://base-mainnet.g.alchemy.com/v2/${ALCHEMY_API_KEY}'],
       webSocket: ['wss://base-mainnet.g.alchemy.com/v2/${ALCHEMY_API_KEY}'],
     },
+    infura: {
+      http: ['https://base-mainnet.infura.io/v3/${INFURA_API_KEY}'],
+      webSocket: ['wss://base-mainnet.infura.io/ws/v3/${INFURA_API_KEY}'],
+    },
   },
   contracts: {
     ...vbase.contracts,

--- a/src/definitions/bsc.ts
+++ b/src/definitions/bsc.ts
@@ -18,6 +18,10 @@ export const bsc: EcoChain = {
       http: ['https://bnb-mainnet.g.alchemy.com/v2/${ALCHEMY_API_KEY}'],
       webSocket: ['wss://bnb-mainnet.g.alchemy.com/v2/${ALCHEMY_API_KEY}'],
     },
+    infura: {
+      http: ['https://bsc-mainnet.infura.io/v3/${INFURA_API_KEY}'],
+      webSocket: ['wss://bsc-mainnet.infura.io/ws/v3/${INFURA_API_KEY}'],
+    },
   },
   contracts: {
     ...vbsc.contracts,

--- a/src/definitions/celo.ts
+++ b/src/definitions/celo.ts
@@ -5,6 +5,13 @@ export const celo: EcoChain = {
   ...vcelo,
   rpcUrls: {
     ...vcelo.rpcUrls,
+    alchemy: {
+      http: ['https://celo-mainnet.g.alchemy.com/v2/${ALCHEMY_API_KEY}'],
+      webSocket: ['wss://celo-mainnet.g.alchemy.com/v2/${ALCHEMY_API_KEY}'],
+    },
+    infura: {
+      http: ['https://celo-mainnet.infura.io/v3/${INFURA_API_KEY}'],
+    },
     quicknode: {
       http: [
         'https://cold-polished-violet.celo-mainnet.quiknode.pro/${QUICKNODE_API_KEY}',

--- a/src/definitions/celo.ts
+++ b/src/definitions/celo.ts
@@ -12,14 +12,6 @@ export const celo: EcoChain = {
     infura: {
       http: ['https://celo-mainnet.infura.io/v3/${INFURA_API_KEY}'],
     },
-    quicknode: {
-      http: [
-        'https://cold-polished-violet.celo-mainnet.quiknode.pro/${QUICKNODE_API_KEY}',
-      ],
-      webSocket: [
-        'wss://cold-polished-violet.celo-mainnet.quiknode.pro/${QUICKNODE_API_KEY}',
-      ],
-    },
   },
   contracts: {
     ...vcelo.contracts,

--- a/src/definitions/ethereum.ts
+++ b/src/definitions/ethereum.ts
@@ -13,6 +13,10 @@ export const ethereum: EcoChain = {
       http: ['https://eth-mainnet.g.alchemy.com/v2/${ALCHEMY_API_KEY}'],
       webSocket: ['wss://eth-mainnet.g.alchemy.com/v2/${ALCHEMY_API_KEY}'],
     },
+    infura: {
+      http: ['https://mainnet.infura.io/v3/${INFURA_API_KEY}'],
+      webSocket: ['wss://mainnet.infura.io/ws/v3/${INFURA_API_KEY}'],
+    },
   },
   contracts: {
     ...vmainnet.contracts,

--- a/src/definitions/hyperevm.ts
+++ b/src/definitions/hyperevm.ts
@@ -18,6 +18,12 @@ export const hyperevm: EcoChain = {
     symbol: 'HYPE',
   },
   rpcUrls: {
+    alchemy: {
+      http: ['https://hyperliquid-mainnet.g.alchemy.com/v2/${ALCHEMY_API_KEY}'],
+      webSocket: [
+        'wss://hyperliquid-mainnet.g.alchemy.com/v2/${ALCHEMY_API_KEY}',
+      ],
+    },
     default: {
       http: ['https://rpc.hyperliquid.xyz/evm'],
     },

--- a/src/definitions/mantle.ts
+++ b/src/definitions/mantle.ts
@@ -9,6 +9,10 @@ export const mantle: EcoChain = {
       http: ['https://mantle-mainnet.g.alchemy.com/v2/${ALCHEMY_API_KEY}'],
       webSocket: ['wss://mantle-mainnet.g.alchemy.com/v2/${ALCHEMY_API_KEY}'],
     },
+    infura: {
+      http: ['https://mantle-mainnet.infura.io/v3/${INFURA_API_KEY}'],
+      webSocket: ['wss://mantle-mainnet.infura.io/ws/v3/${INFURA_API_KEY}'],
+    },
   },
   contracts: {
     ...vmantle.contracts,

--- a/src/definitions/optimism.ts
+++ b/src/definitions/optimism.ts
@@ -5,15 +5,13 @@ export const optimism: EcoChain = {
   ...vop,
   rpcUrls: {
     ...vop.rpcUrls,
-    custom: {
-      http: [
-        'https://opt-mainnet.g.alchemy.com/v2/${ALCHEMY_API_KEY}',
-        'https://optimism-mainnet.infura.io/v3/${INFURA_API_KEY}',
-      ],
-      webSocket: [
-        'wss://opt-mainnet.g.alchemy.com/v2/${ALCHEMY_API_KEY}',
-        'wss://optimism-mainnet.infura.io/ws/v3/${INFURA_API_KEY}',
-      ],
+    alchemy: {
+      http: ['https://opt-mainnet.g.alchemy.com/v2/${ALCHEMY_API_KEY}'],
+      webSocket: ['wss://opt-mainnet.g.alchemy.com/v2/${ALCHEMY_API_KEY}'],
+    },
+    infura: {
+      http: ['https://optimism-mainnet.infura.io/v3/${INFURA_API_KEY}'],
+      webSocket: ['wss://optimism-mainnet.infura.io/ws/v3/${INFURA_API_KEY}'],
     },
   },
   contracts: {

--- a/src/definitions/polygon.ts
+++ b/src/definitions/polygon.ts
@@ -9,6 +9,10 @@ export const polygon: EcoChain = {
       http: ['https://polygon-mainnet.g.alchemy.com/v2/${ALCHEMY_API_KEY}'],
       webSocket: ['wss://polygon-mainnet.g.alchemy.com/v2/${ALCHEMY_API_KEY}'],
     },
+    infura: {
+      http: ['https://polygon-mainnet.infura.io/v3/${INFURA_API_KEY}'],
+      webSocket: ['wss://polygon-mainnet.infura.io/ws/v3/${INFURA_API_KEY}'],
+    },
   },
   contracts: {
     ...vpolygon.contracts,

--- a/src/definitions/unichain.ts
+++ b/src/definitions/unichain.ts
@@ -9,6 +9,9 @@ export const unichain: EcoChain = {
       http: ['https://unichain-mainnet.g.alchemy.com/v2/${ALCHEMY_API_KEY}'],
       webSocket: ['wss://unichain-mainnet.g.alchemy.com/v2/${ALCHEMY_API_KEY}'],
     },
+    infura: {
+      http: ['https://unichain-mainnet.infura.io/v3/${INFURA_API_KEY}'],
+    },
   },
   isCalderaChain: false,
   stables: {

--- a/src/eco.chains.ts
+++ b/src/eco.chains.ts
@@ -10,7 +10,6 @@ export const ConfigRegex = {
   alchemyKey: /\$\{ALCHEMY_API_KEY\}/, // Matches Alchemy API key placeholder
   infuraKey: /\$\{INFURA_API_KEY\}/, // Matches Infura API key placeholder
   mantaKey: /\$\{MANTA_API_KEY\}/, // Matches Manta API key placeholder
-  quickNodeKey: /\$\{QUICKNODE_API_KEY\}/, // Matches MQUICKNODE_API_KEY key placeholder
   curtisKey: /\$\{CURTIS_API_KEY\}/, // Matches Curtis API key placeholder
 }
 

--- a/src/tests/eco.chains.spec.ts
+++ b/src/tests/eco.chains.spec.ts
@@ -19,7 +19,6 @@ describe('Eco Chains', () => {
     alchemyKey: 'api_key_123',
     mantaKey: 'manta_key_789',
     curtisKey: 'curtis_key_xyz',
-    quickNodeKey: 'quick_node_key_456',
     infuraKey: 'infura_key_abc',
   }
 
@@ -28,7 +27,6 @@ describe('Eco Chains', () => {
     infura: any = {},
     manta: any = {},
     curtis: any = {},
-    quickNode: any = {},
     mixedCustomGroup: any = {}
   beforeEach(() => {
     // Reset all mocks
@@ -58,14 +56,6 @@ describe('Eco Chains', () => {
     curtis = {
       http: ['https://curtis.rpc.caldera.xyz/${CURTIS_API_KEY}'],
       webSocket: ['wss://curtis.rpc.caldera.xyz/'],
-    }
-    quickNode = {
-      http: [
-        'https://sparkling-wispy-crater.matic.discover.quiknode.pro/${QUICKNODE_API_KEY}',
-      ],
-      webSocket: [
-        'wss://sparkling-wispy-crater.matic.discover.quiknode.pro/${QUICKNODE_API_KEY}',
-      ],
     }
     mixedCustomGroup = {
       http: [
@@ -175,32 +165,6 @@ describe('Eco Chains', () => {
     expect(chain1.rpcUrls).toHaveProperty('custom')
     // Last provider might be manta, curtis or something else - just verify it exists
     expect(chain1.rpcUrls.custom).toEqual(curtisEq)
-  })
-
-  it('should replace QuickNode RPC URLs with API key', async () => {
-    const rpcs = getRpcUrls({ default: defaults, quickNode })
-    mockViemExtract.mockReturnValue(cloneDeep(rpcs))
-    const obj = new EcoChains(config)
-    expect(obj).toBeDefined()
-    const chain1 = obj.getChain(1)
-    expect(chain1.rpcUrls.default).toEqual(rpcs.rpcUrls.default)
-
-    const quickNodeEq = {
-      http: [
-        'https://sparkling-wispy-crater.matic.discover.quiknode.pro/' +
-          config.quickNodeKey,
-      ],
-      webSocket: [
-        'wss://sparkling-wispy-crater.matic.discover.quiknode.pro/' +
-          config.quickNodeKey,
-      ],
-    }
-    expect(chain1.rpcUrls.quickNode).toEqual(quickNodeEq)
-
-    // Verify that the custom RPC group exists
-    expect(chain1.rpcUrls).toHaveProperty('custom')
-    // The custom group should be set to the QuickNode URLs
-    expect(chain1.rpcUrls.custom).toEqual(quickNodeEq)
   })
 
   it('should handle a custom group with mixed providers', async () => {


### PR DESCRIPTION
Using rpc provider naming convention or simply default for some caldera chains that don't exist in viem.