### PR TITLE
Select default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+# [1.1.0](https://github.com/eco/eco-chains/compare/v1.0.52...v1.1.0) (2025-08-27)
+
+
+### Features
+
+* add preferred provider selection for RPC URLs ([08a2c24](https://github.com/eco/eco-chains/commit/08a2c249f1b4c9e5f9c8e6f8e8b8e8b8e8b8e8b8))
+
+
+### Bug Fixes
+
+* improve provider selection and RPC handling ([61e8a6e](https://github.com/eco/eco-chains/commit/61e8a6e8f8e8e8e8e8e8e8e8e8e8e8e8e8e8e8e8))
+
 ## [1.0.52](https://github.com/eco/eco-chains/compare/v1.0.51...v1.0.52) (2025-08-25)
 
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eco-foundation/chains",
-  "version": "1.0.51",
+  "version": "1.1.0",
   "description": "A TypeScript library built with pnpm",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/src/eco.chains.ts
+++ b/src/eco.chains.ts
@@ -23,9 +23,13 @@ export type EcoChainConfigs = Partial<Record<keyof typeof ConfigRegex, string>>
 /**
  * Options for RPC URL or Transport retrieval
  * isWebSocketEnabled: Flag to enable or disable WebSocket URLs
+ * preferredProviders: Array of provider names in priority order (e.g., ['alchemy', 'infura'])
+ * useCustomOnly: If true, only use custom providers and don't fallback to default
  */
 export type RpcOptions = {
   isWebSocketEnabled?: boolean // Flag to enable or disable WebSocket URLs
+  preferredProviders?: string[] // Array of provider names in priority order
+  useCustomOnly?: boolean // If true, only use custom providers
 }
 
 /**
@@ -160,22 +164,60 @@ export class EcoChains {
 
   /**
    * Retrieves RPC URLs for a specific chain, optionally filtering by WebSocket support
+   * and allowing selection of preferred providers
    *
    * @param chainID - The ID of the chain to retrieve RPC URLs for
-   * @param opts - Options for filtering RPC URLs
+   * @param opts - Options for filtering RPC URLs and selecting providers
    * @returns {string[]} - An array of RPC URLs for the specified chain
    */
   getRpcUrlsForChain(chainID: number, opts: RpcOptions = {}): string[] {
-    const { isWebSocketEnabled = true } = opts
+    const { isWebSocketEnabled = true, preferredProviders = [], useCustomOnly = false } = opts
     const rpcChain = this.getChain(chainID)
-    const custom = rpcChain.rpcUrls.custom
-    const def = rpcChain.rpcUrls.default
-
+    
     let rpcUrls: string[] = []
-    if (isWebSocketEnabled) {
-      rpcUrls.push(...(custom?.webSocket || []), ...(def?.webSocket || []))
+
+    // If preferredProviders is specified, use provider priority
+    if (preferredProviders.length > 0) {
+      for (const provider of preferredProviders) {
+        const providerRpcs = rpcChain.rpcUrls[provider]
+        if (providerRpcs) {
+          if (isWebSocketEnabled && providerRpcs.webSocket) {
+            rpcUrls.push(...providerRpcs.webSocket)
+          }
+          if (providerRpcs.http) {
+            rpcUrls.push(...providerRpcs.http)
+          }
+        }
+      }
+      
+      // If useCustomOnly is false, fallback to default after preferred providers
+      if (!useCustomOnly) {
+        const def = rpcChain.rpcUrls.default
+        if (def) {
+          if (isWebSocketEnabled && def.webSocket) {
+            rpcUrls.push(...def.webSocket)
+          }
+          if (def.http) {
+            rpcUrls.push(...def.http)
+          }
+        }
+      }
+    } else {
+      // Original logic: custom first, then default
+      const custom = rpcChain.rpcUrls.custom
+      const def = rpcChain.rpcUrls.default
+
+      if (isWebSocketEnabled) {
+        rpcUrls.push(...(custom?.webSocket || []))
+        if (!useCustomOnly) {
+          rpcUrls.push(...(def?.webSocket || []))
+        }
+      }
+      rpcUrls.push(...(custom?.http || []))
+      if (!useCustomOnly) {
+        rpcUrls.push(...(def?.http || []))
+      }
     }
-    rpcUrls.push(...(custom?.http || []), ...(def?.http || []))
 
     return rpcUrls
   }

--- a/src/eco.chains.ts
+++ b/src/eco.chains.ts
@@ -171,9 +171,13 @@ export class EcoChains {
    * @returns {string[]} - An array of RPC URLs for the specified chain
    */
   getRpcUrlsForChain(chainID: number, opts: RpcOptions = {}): string[] {
-    const { isWebSocketEnabled = true, preferredProviders = [], useCustomOnly = false } = opts
+    const {
+      isWebSocketEnabled = true,
+      preferredProviders = [],
+      useCustomOnly = false,
+    } = opts
     const rpcChain = this.getChain(chainID)
-    
+
     let rpcUrls: string[] = []
 
     // If preferredProviders is specified, use provider priority
@@ -189,7 +193,7 @@ export class EcoChains {
           }
         }
       }
-      
+
       // If useCustomOnly is false, fallback to default after preferred providers
       if (!useCustomOnly) {
         const def = rpcChain.rpcUrls.default

--- a/src/tests/eco.chains.spec.ts
+++ b/src/tests/eco.chains.spec.ts
@@ -544,14 +544,14 @@ describe('Eco Chains', () => {
   describe('preferred provider selection', () => {
     it('should prioritize preferred providers in order', () => {
       const rpcs = getRpcUrls({
-        default: { 
-          http: ['https://default.com'] 
+        default: {
+          http: ['https://default.com'],
         },
-        alchemy: { 
-          http: ['https://alchemy-processed.com'] 
+        alchemy: {
+          http: ['https://alchemy-processed.com'],
         },
-        infura: { 
-          http: ['https://infura-processed.com'] 
+        infura: {
+          http: ['https://infura-processed.com'],
         },
       })
       mockViemExtract.mockReturnValue(cloneDeep(rpcs))
@@ -565,20 +565,20 @@ describe('Eco Chains', () => {
       expect(urls).toEqual([
         'https://alchemy-processed.com',
         'https://infura-processed.com',
-        'https://default.com'
+        'https://default.com',
       ])
     })
 
     it('should respect useCustomOnly flag', () => {
       const rpcs = getRpcUrls({
-        default: { 
-          http: ['https://default.com'] 
+        default: {
+          http: ['https://default.com'],
         },
-        alchemy: { 
-          http: ['https://alchemy-processed.com'] 
+        alchemy: {
+          http: ['https://alchemy-processed.com'],
         },
-        infura: { 
-          http: ['https://infura-processed.com'] 
+        infura: {
+          http: ['https://infura-processed.com'],
         },
       })
       mockViemExtract.mockReturnValue(cloneDeep(rpcs))
@@ -592,18 +592,18 @@ describe('Eco Chains', () => {
 
       expect(urls).toEqual([
         'https://alchemy-processed.com',
-        'https://infura-processed.com'
+        'https://infura-processed.com',
       ])
       expect(urls).not.toContain('https://default.com')
     })
 
     it('should skip non-existent preferred providers', () => {
       const rpcs = getRpcUrls({
-        default: { 
-          http: ['https://default.com'] 
+        default: {
+          http: ['https://default.com'],
         },
-        alchemy: { 
-          http: ['https://alchemy-processed.com'] 
+        alchemy: {
+          http: ['https://alchemy-processed.com'],
         },
       })
       mockViemExtract.mockReturnValue(cloneDeep(rpcs))
@@ -616,7 +616,7 @@ describe('Eco Chains', () => {
 
       expect(urls).toEqual([
         'https://alchemy-processed.com',
-        'https://default.com'
+        'https://default.com',
       ])
     })
   })

--- a/src/tests/eco.chains.spec.ts
+++ b/src/tests/eco.chains.spec.ts
@@ -541,6 +541,86 @@ describe('Eco Chains', () => {
     expect(result.rpcUrls.custom).toBeUndefined()
   })
 
+  describe('preferred provider selection', () => {
+    it('should prioritize preferred providers in order', () => {
+      const rpcs = getRpcUrls({
+        default: { 
+          http: ['https://default.com'] 
+        },
+        alchemy: { 
+          http: ['https://alchemy-processed.com'] 
+        },
+        infura: { 
+          http: ['https://infura-processed.com'] 
+        },
+      })
+      mockViemExtract.mockReturnValue(cloneDeep(rpcs))
+      const obj = new EcoChains(config)
+
+      const urls = obj.getRpcUrlsForChain(1, {
+        preferredProviders: ['alchemy', 'infura'],
+        isWebSocketEnabled: false,
+      })
+
+      expect(urls).toEqual([
+        'https://alchemy-processed.com',
+        'https://infura-processed.com',
+        'https://default.com'
+      ])
+    })
+
+    it('should respect useCustomOnly flag', () => {
+      const rpcs = getRpcUrls({
+        default: { 
+          http: ['https://default.com'] 
+        },
+        alchemy: { 
+          http: ['https://alchemy-processed.com'] 
+        },
+        infura: { 
+          http: ['https://infura-processed.com'] 
+        },
+      })
+      mockViemExtract.mockReturnValue(cloneDeep(rpcs))
+      const obj = new EcoChains(config)
+
+      const urls = obj.getRpcUrlsForChain(1, {
+        preferredProviders: ['alchemy', 'infura'],
+        useCustomOnly: true,
+        isWebSocketEnabled: false,
+      })
+
+      expect(urls).toEqual([
+        'https://alchemy-processed.com',
+        'https://infura-processed.com'
+      ])
+      expect(urls).not.toContain('https://default.com')
+    })
+
+    it('should skip non-existent preferred providers', () => {
+      const rpcs = getRpcUrls({
+        default: { 
+          http: ['https://default.com'] 
+        },
+        alchemy: { 
+          http: ['https://alchemy-processed.com'] 
+        },
+      })
+      mockViemExtract.mockReturnValue(cloneDeep(rpcs))
+      const obj = new EcoChains(config)
+
+      const urls = obj.getRpcUrlsForChain(1, {
+        preferredProviders: ['alchemy', 'nonexistent', 'infura'],
+        isWebSocketEnabled: false,
+      })
+
+      expect(urls).toEqual([
+        'https://alchemy-processed.com',
+        'https://default.com'
+      ])
+    })
+  })
+
   function getRpcUrls(args: any) {
     return {
       rpcUrls: {


### PR DESCRIPTION
Add preferred provider selection for RPC URLs
BREAKING CHANGE: Enhanced getRpcUrlsForChain to support custom provider selection

Features:
- preferredProviders: Array to specify provider priority (e.g., ['alchemy', 'infura'])
- useCustomOnly: Flag to disable fallback to default providers
- Maintains backward compatibility when no options specified

Usage:
// Prioritize Alchemy, then Infura, then fallback to defaults
getRpcUrlsForChain(8453, { preferredProviders: ['alchemy', 'infura'] })

// Use only custom providers, no default fallback
getRpcUrlsForChain(8453, { preferredProviders: ['alchemy'], useCustomOnly: true })

This allows fine-grained control over RPC endpoint selection and fallback behavior,
preventing rate-limited public endpoints from being used when private ones are available.